### PR TITLE
chore : 유저의 디바이스 토큰 없을 경우 노티 안보내게 수정

### DIFF
--- a/src/modules/notification/services/chat-notification.service.ts
+++ b/src/modules/notification/services/chat-notification.service.ts
@@ -30,6 +30,7 @@ export class ChatNotificationService {
     const receiver = await this.roomUserRepository.getMatchingUser(senderId, roomId);
     const sender = await this.userRepository.get({ id: senderId });
     const deviceTokenObjects = await this.deviceTokenRepository.findAll(receiver.id);
+    if (deviceTokenObjects.length === 0) return;
     const deviceTokenValues = deviceTokenObjects.map(deviceTokenObject => deviceTokenObject.value);
 
     const payload: firebaseAdmin.messaging.MessagingPayload = {

--- a/src/modules/notification/services/signal-notification.service.ts
+++ b/src/modules/notification/services/signal-notification.service.ts
@@ -30,9 +30,8 @@ export class SignalNotificationService {
     for (let i = 0; i < signal.length; i++) {
       const receiverId: number = signal[i].receiverId;
       const deviceTokenObjects = await this.deviceTokenRepository.findAll(receiverId);
+      if (deviceTokenObjects.length === 0) continue;
       const deviceTokenValue = deviceTokenObjects.map(deviceTokenObject => deviceTokenObject.value);
-
-      if (!deviceTokenValue) continue;
       const keyword = signal[i].keywords.split(',');
       const keywordList = keyword.map(item => item.trim());
       const displayedMatchingKeywordString =


### PR DESCRIPTION
- 업데이트 안한 유저의 경우 디바이스토큰이 없음. 업데이트 안한 유저에게 시그널이 전달되면 오류가 남
- 디바이스토큰을 찾을 수 없는 유저의 경우 노티를 보내지 않게 수정